### PR TITLE
Prefer computed properties over functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -351,6 +351,22 @@ var diameter: Double {
 }
 ```
 
+Prefer computed properties over non-mutating, returning functions.
+
+**Preferred:**
+```swift
+var diameter: Double {
+  return radius * 2
+}
+```
+
+**Not Preferred:**
+```swift
+func diameter() -> Double {
+    return radius * 2
+}
+```
+
 ## Function Declarations
 
 Keep short function declarations on one line including the opening brace:


### PR DESCRIPTION
@iovortex @JosephSouthern @sallyransom @yfujiki @tLewisII I propose we prefer computed properties over simple returning functions where we are not mutating properties or taking arguments. This leads to cleaner looking code with fewer `()` scattered about.
